### PR TITLE
exchanged deprecated systemSettings variable

### DIFF
--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -17,7 +17,7 @@
 
 {% do view.registerAssetBundle("by\\guestentriesnotification\\assetbundles\\guestentriesnotification\\GuestEntriesNotificationAsset") %}
 
-{% set systemSettings = craft.systemSettings.email %}
+{% set systemSettings = craft.app.projectConfig.get('email') %}
 
 {% set defaultEmail = systemSettings.fromEmail %}
 


### PR DESCRIPTION
This should remove the deprecation warning : "craft.systemSettings.[category] has been deprecated. Use craft.app.projectConfig.get('category') instead."