### PR TITLE
Fix asset bundle for PSR-4 autoloader compatible

### DIFF
--- a/src/assetbundles/guestentriesnotification/GuestEntriesNotificationAsset.php
+++ b/src/assetbundles/guestentriesnotification/GuestEntriesNotificationAsset.php
@@ -8,7 +8,7 @@
  * @copyright Copyright (c) 2018 Bhashkar Yadav
  */
 
-namespace by\guestentriesnotification\assetbundles\GuestEntriesNotification;
+namespace by\guestentriesnotification\assetbundles\guestentriesnotification;
 
 use Craft;
 use craft\web\AssetBundle;


### PR DESCRIPTION
This PR fixes the plugins asset bundle namespace declaration to be PSR-4 compatible, so that the package can be installed under composer 2.x